### PR TITLE
fix: cap border radius for cards when pill radius is selected

### DIFF
--- a/src/components/preview/templates/BlogPreview.tsx
+++ b/src/components/preview/templates/BlogPreview.tsx
@@ -18,13 +18,14 @@ function usePreviewStyles() {
     secondary: "#a855f7", accent: "#ec4899", muted: "#f1f5f9", border: "#e2e8f0",
   };
   const r = RADIUS_MAP[state.borderRadius];
+  const cardR = r === "999px" ? "24px" : r;
   const s = SHADOW_MAP[state.shadowStyle];
   const d = DENSITY_MAP[state.density];
   const headingFont = fontPairing ? `'${fontPairing.heading.family}', sans-serif` : "sans-serif";
   const bodyFont = fontPairing ? `'${fontPairing.body.family}', sans-serif` : "sans-serif";
   const glow = state.effects.glow;
 
-  return { c, r, s, d, headingFont, bodyFont, glow };
+  return { c, r, cardR, s, d, headingFont, bodyFont, glow };
 }
 
 const posts = [
@@ -69,7 +70,7 @@ const posts = [
 const sidebarTags = ["Design", "Typography", "Color", "Engineering", "Product", "UX Research"];
 
 export function BlogPreview() {
-  const { c, r, s, d, headingFont, bodyFont, glow } = usePreviewStyles();
+  const { c, r, cardR, s, d, headingFont, bodyFont, glow } = usePreviewStyles();
 
   const featured = posts[0];
   const rest = posts.slice(1);
@@ -99,7 +100,7 @@ export function BlogPreview() {
           <div
             className="overflow-hidden"
             style={{
-              borderRadius: r,
+              borderRadius: cardR,
               boxShadow: s,
               border: `1px solid ${c.border}`,
               backgroundColor: c.background,
@@ -177,7 +178,7 @@ export function BlogPreview() {
                 key={post.title}
                 className="flex gap-4 p-4"
                 style={{
-                  borderRadius: r,
+                  borderRadius: cardR,
                   boxShadow: s,
                   border: `1px solid ${c.border}`,
                   backgroundColor: c.background,
@@ -186,7 +187,7 @@ export function BlogPreview() {
                 {/* Thumbnail */}
                 <div
                   className="w-24 h-24 shrink-0"
-                  style={{ backgroundColor: c.muted, borderRadius: r }}
+                  style={{ backgroundColor: c.muted, borderRadius: cardR }}
                 />
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 mb-1">
@@ -259,7 +260,7 @@ export function BlogPreview() {
             <div
               className="p-4"
               style={{
-                borderRadius: r,
+                borderRadius: cardR,
                 backgroundColor: c.primary + "10",
                 border: `1px solid ${c.primary}30`,
               }}

--- a/src/components/preview/templates/EcommercePreview.tsx
+++ b/src/components/preview/templates/EcommercePreview.tsx
@@ -18,13 +18,14 @@ function usePreviewStyles() {
     secondary: "#a855f7", accent: "#ec4899", muted: "#f1f5f9", border: "#e2e8f0",
   };
   const r = RADIUS_MAP[state.borderRadius];
+  const cardR = r === "999px" ? "24px" : r;
   const s = SHADOW_MAP[state.shadowStyle];
   const d = DENSITY_MAP[state.density];
   const headingFont = fontPairing ? `'${fontPairing.heading.family}', sans-serif` : "sans-serif";
   const bodyFont = fontPairing ? `'${fontPairing.body.family}', sans-serif` : "sans-serif";
   const glow = state.effects.glow;
 
-  return { c, r, s, d, headingFont, bodyFont, glow };
+  return { c, r, cardR, s, d, headingFont, bodyFont, glow };
 }
 
 const products = [
@@ -39,7 +40,7 @@ const products = [
 const categories = ["All", "Clothing", "Accessories", "Shoes", "Bags"];
 
 export function EcommercePreview() {
-  const { c, r, s, d, headingFont, bodyFont, glow } = usePreviewStyles();
+  const { c, r, cardR, s, d, headingFont, bodyFont, glow } = usePreviewStyles();
 
   return (
     <div style={{ fontFamily: bodyFont }}>
@@ -117,7 +118,7 @@ export function EcommercePreview() {
                 key={product.name}
                 className="group flex flex-col overflow-hidden"
                 style={{
-                  borderRadius: r,
+                  borderRadius: cardR,
                   boxShadow: s,
                   border: `1px solid ${c.border}`,
                   backgroundColor: c.background,

--- a/src/components/preview/templates/LandingPreview.tsx
+++ b/src/components/preview/templates/LandingPreview.tsx
@@ -20,17 +20,18 @@ function usePreviewStyles() {
     secondary: "#a855f7", accent: "#ec4899", muted: "#f1f5f9", border: "#e2e8f0",
   };
   const r = RADIUS_MAP[state.borderRadius];
+  const cardR = r === "999px" ? "24px" : r;
   const s = SHADOW_MAP[state.shadowStyle];
   const d = DENSITY_MAP[state.density];
   const headingFont = fontPairing ? `'${fontPairing.heading.family}', sans-serif` : "sans-serif";
   const bodyFont = fontPairing ? `'${fontPairing.body.family}', sans-serif` : "sans-serif";
   const glow = state.effects.glow;
 
-  return { c, r, s, d, headingFont, bodyFont, glow, state };
+  return { c, r, cardR, s, d, headingFont, bodyFont, glow, state };
 }
 
 export function LandingPreview() {
-  const { c, r, s, d, headingFont, bodyFont, glow, state } = usePreviewStyles();
+  const { c, r, cardR, s, d, headingFont, bodyFont, glow, state } = usePreviewStyles();
 
   const btnStyle: React.CSSProperties = {
     backgroundColor: c.primary,
@@ -46,7 +47,7 @@ export function LandingPreview() {
 
   const cardStyle: React.CSSProperties = {
     backgroundColor: c.muted,
-    borderRadius: r,
+    borderRadius: cardR,
     boxShadow: s,
     border: `1px solid ${c.border}`,
     fontFamily: bodyFont,


### PR DESCRIPTION
## Summary
- Cards and containers now cap at 24px border radius when pill (999px) is selected, preventing oval/circular card distortion
- Buttons, badges, tags, and chips still use the full pill radius for the intended effect

Closes #21

## What changed
- `src/components/preview/templates/LandingPreview.tsx`: Added `cardR` variable, used for card elements
- `src/components/preview/templates/EcommercePreview.tsx`: Same — product cards use capped radius
- `src/components/preview/templates/BlogPreview.tsx`: Same — featured article, article cards, thumbnails, newsletter box use capped radius

## How to test
1. Navigate to `/builder` → Effects step
2. Set Border Radius to "Pill"
3. Set Density to "Condensed" (makes the issue most visible)
4. Check all 3 page types (Landing, E-commerce, Blog)
5. Confirm: cards look like rounded rectangles (not ovals)
6. Confirm: buttons remain pill-shaped

🤖 Generated with [Claude Code](https://claude.com/claude-code)