### PR TITLE
fix: isolate preview theming from wizard chrome

### DIFF
--- a/src/components/preview/PreviewPanel.tsx
+++ b/src/components/preview/PreviewPanel.tsx
@@ -87,7 +87,7 @@ export function PreviewPanel() {
   const isMobile = state.previewViewport === "mobile";
 
   const previewContent = (
-    <div className="min-h-full" style={cssVars}>
+    <div className="min-h-full overflow-hidden" style={cssVars}>
       <div
         className="relative min-h-screen"
         style={{
@@ -125,7 +125,7 @@ export function PreviewPanel() {
 
   if (isMobile) {
     return (
-      <div className="h-full overflow-auto flex items-start justify-center bg-muted/50 p-6" ref={containerRef}>
+      <div className="h-full overflow-auto isolate flex items-start justify-center bg-muted/50 p-6" ref={containerRef}>
         <div
           className="relative w-[375px] min-h-[667px] rounded-[2rem] border-[8px] border-foreground/20 overflow-hidden shadow-2xl bg-background"
         >
@@ -136,7 +136,7 @@ export function PreviewPanel() {
   }
 
   return (
-    <div className="h-full overflow-auto" ref={containerRef}>
+    <div className="h-full overflow-auto isolate" ref={containerRef}>
       {previewContent}
     </div>
   );

--- a/src/components/wizard/WizardShell.tsx
+++ b/src/components/wizard/WizardShell.tsx
@@ -40,7 +40,7 @@ export function WizardShell() {
   return (
     <div className="flex h-screen bg-background overflow-hidden">
       {/* Sidebar - hidden on mobile */}
-      <div className="hidden md:block">
+      <div className="hidden md:block relative z-10">
         <WizardSidebar onGeneratePrompt={() => setShowPrompt(true)} />
       </div>
 
@@ -48,7 +48,7 @@ export function WizardShell() {
       <div className="flex flex-1 flex-col md:flex-row overflow-hidden">
         {/* Left: Wizard controls */}
         <div
-          className={`w-full md:w-[420px] lg:w-[480px] flex flex-col border-r border-border bg-background ${
+          className={`w-full md:w-[420px] lg:w-[480px] flex flex-col border-r border-border bg-background relative z-10 ${
             mobileView === "preview" ? "hidden md:flex" : "flex"
           }`}
         >
@@ -125,7 +125,7 @@ export function WizardShell() {
 
         {/* Right: Live preview */}
         <div
-          className={`flex-1 bg-muted/30 overflow-hidden flex flex-col ${
+          className={`flex-1 bg-muted/30 overflow-hidden isolate flex flex-col ${
             mobileView === "controls" ? "hidden md:flex" : "flex"
           }`}
         >


### PR DESCRIPTION
## Summary
- Added CSS isolation (`isolate`, `overflow-hidden`) to the preview container to prevent dark-themed previews from visually bleeding into wizard controls
- Added `relative z-10` to sidebar and controls to ensure they render above the preview's stacking context

Closes #30

## What changed
- `src/components/wizard/WizardShell.tsx`: Added `relative z-10` to sidebar wrapper and controls panel; added `isolate` to preview wrapper
- `src/components/preview/PreviewPanel.tsx`: Added `isolate` and `overflow-hidden` to preview container

## How to test
1. Navigate to `/builder` → Style step
2. Select Glassmorphism, Cinematic Noir, or Terminal Hacker (dark themes)
3. Confirm: sidebar and controls maintain light theme appearance
4. Confirm: preview shows the dark style correctly
5. Toggle between dark and light styles rapidly — no visual artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)