### PR TITLE
feat: add always-visible Generate Prompt button to sidebar

### DIFF
--- a/src/components/wizard/WizardShell.tsx
+++ b/src/components/wizard/WizardShell.tsx
@@ -37,7 +37,7 @@ export function WizardShell() {
     <div className="flex h-screen bg-background overflow-hidden">
       {/* Sidebar - hidden on mobile */}
       <div className="hidden md:block">
-        <WizardSidebar />
+        <WizardSidebar onGeneratePrompt={() => setShowPrompt(true)} />
       </div>
 
       {/* Main content area */}
@@ -94,12 +94,19 @@ export function WizardShell() {
                 Preview
               </Button>
 
-              {isLastStep ? (
-                <Button size="sm" onClick={() => setShowPrompt(true)}>
+              {/* Mobile-only generate prompt button */}
+              {isLastStep && (
+                <Button
+                  size="sm"
+                  className="md:hidden"
+                  onClick={() => setShowPrompt(true)}
+                >
                   <Code2 className="h-4 w-4 mr-1" />
-                  Generate Prompt
+                  Generate
                 </Button>
-              ) : (
+              )}
+
+              {!isLastStep && (
                 <Button
                   size="sm"
                   onClick={() => setStep(currentStep + 1)}

--- a/src/components/wizard/WizardSidebar.tsx
+++ b/src/components/wizard/WizardSidebar.tsx
@@ -9,8 +9,10 @@ import {
   Type,
   LayoutGrid,
   Sparkles,
+  Code2,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 
 const iconMap = {
   Layout,
@@ -21,7 +23,11 @@ const iconMap = {
   Sparkles,
 } as const;
 
-export function WizardSidebar() {
+interface WizardSidebarProps {
+  onGeneratePrompt: () => void;
+}
+
+export function WizardSidebar({ onGeneratePrompt }: WizardSidebarProps) {
   const currentStep = useWizardStore((s) => s.currentStep);
   const setStep = useWizardStore((s) => s.setStep);
 
@@ -37,7 +43,7 @@ export function WizardSidebar() {
         {WIZARD_STEPS.map((step) => {
           const Icon = iconMap[step.icon as keyof typeof iconMap];
           const isActive = currentStep === step.id;
-          const isCompleted = currentStep > step.id;
+          const isPast = currentStep > step.id;
 
           return (
             <button
@@ -47,25 +53,27 @@ export function WizardSidebar() {
                 "flex items-center gap-3 w-full px-3 py-2.5 rounded-lg text-sm font-medium transition-colors text-left",
                 isActive
                   ? "bg-primary text-primary-foreground"
-                  : isCompleted
+                  : isPast
                     ? "text-foreground hover:bg-muted"
                     : "text-muted-foreground hover:bg-muted hover:text-foreground"
               )}
             >
               <Icon className="h-4 w-4 shrink-0" />
               <span>{step.label}</span>
-              {isCompleted && (
-                <span className="ml-auto text-xs opacity-60">✓</span>
-              )}
             </button>
           );
         })}
       </nav>
 
-      <div className="p-4 border-t border-border">
-        <p className="text-xs text-muted-foreground">
-          Step {currentStep + 1} of {WIZARD_STEPS.length}
-        </p>
+      <div className="p-3 border-t border-border">
+        <Button
+          className="w-full"
+          size="sm"
+          onClick={onGeneratePrompt}
+        >
+          <Code2 className="h-4 w-4 mr-1.5" />
+          Generate Prompt
+        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Added a persistent "Generate Prompt" button at the bottom of the sidebar, always visible regardless of current wizard step (#25)
- Standardized button sizing: sidebar CTA uses `size="sm"`, nav buttons use `size="sm"` consistently (#4)
- Sidebar step counter removed and replaced with the CTA button
- Sidebar checkmark indicators also removed (misleading "past step" tracking)
- Mobile users still see Generate on the last step's nav footer since the sidebar is hidden

Closes #25
Closes #4

## What changed
- `src/components/wizard/WizardSidebar.tsx`: Added `onGeneratePrompt` prop, added Generate Prompt button in footer area, removed checkmark and step counter
- `src/components/wizard/WizardShell.tsx`: Passes `onGeneratePrompt` callback, nav footer shows Generate only on mobile for last step

## How to test
1. Navigate to `/builder`
2. From any step, confirm "Generate Prompt" button is visible at bottom of sidebar
3. Click it — modal opens with correct prompt
4. Resize to mobile width — sidebar disappears, Generate appears in footer on last step
5. Confirm all buttons have consistent sizing

🤖 Generated with [Claude Code](https://claude.com/claude-code)