### PR TITLE
fix: improve brand color legibility with WCAG contrast checking

### DIFF
--- a/src/components/preview/PreviewPanel.tsx
+++ b/src/components/preview/PreviewPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useWizardStore } from "@/store/wizard-store";
 import { getStyleById } from "@/data/styles";
-import { getColorTheme, generatePaletteFromBrand } from "@/data/colors";
+import { getColorTheme, generatePaletteFromBrand, isColorDark } from "@/data/colors";
 import { getFontPairing } from "@/data/typography";
 import { RADIUS_MAP, SHADOW_MAP } from "@/types";
 import { LandingPreview } from "./templates/LandingPreview";
@@ -15,8 +15,9 @@ export function PreviewPanel() {
   const containerRef = useRef<HTMLDivElement>(null);
 
   const style = getStyleById(state.styleId);
+  const styleIsDark = style ? isColorDark(style.tokens.bgBase) : false;
   const colorTheme = state.customBrandColor
-    ? generatePaletteFromBrand(state.customBrandColor, style?.tokens.bgBase === "#000000" || style?.tokens.bgBase === "#0a0a0a" || style?.tokens.bgBase === "#0d1117" || style?.tokens.bgBase === "#0f0f23" || style?.tokens.bgBase === "#1a1a2e" || style?.tokens.bgBase === "#0c0c0c")
+    ? generatePaletteFromBrand(state.customBrandColor, styleIsDark)
     : getColorTheme(state.colorThemeId);
   const fontPairing = getFontPairing(state.fontPairingId);
 

--- a/src/components/preview/templates/BlogPreview.tsx
+++ b/src/components/preview/templates/BlogPreview.tsx
@@ -2,14 +2,17 @@
 
 import { useWizardStore } from "@/store/wizard-store";
 import { RADIUS_MAP, SHADOW_MAP, DENSITY_MAP } from "@/types";
-import { getColorTheme, generatePaletteFromBrand } from "@/data/colors";
+import { getColorTheme, generatePaletteFromBrand, isColorDark } from "@/data/colors";
 import { getFontPairing } from "@/data/typography";
+import { getStyleById } from "@/data/styles";
 import { Clock, User, Tag, ArrowRight, Bookmark } from "lucide-react";
 
 function usePreviewStyles() {
   const state = useWizardStore();
+  const style = getStyleById(state.styleId);
+  const styleIsDark = style ? isColorDark(style.tokens.bgBase) : false;
   const colorTheme = state.customBrandColor
-    ? generatePaletteFromBrand(state.customBrandColor, false)
+    ? generatePaletteFromBrand(state.customBrandColor, styleIsDark)
     : getColorTheme(state.colorThemeId);
   const fontPairing = getFontPairing(state.fontPairingId);
 

--- a/src/components/preview/templates/EcommercePreview.tsx
+++ b/src/components/preview/templates/EcommercePreview.tsx
@@ -2,14 +2,17 @@
 
 import { useWizardStore } from "@/store/wizard-store";
 import { RADIUS_MAP, SHADOW_MAP, DENSITY_MAP } from "@/types";
-import { getColorTheme, generatePaletteFromBrand } from "@/data/colors";
+import { getColorTheme, generatePaletteFromBrand, isColorDark } from "@/data/colors";
 import { getFontPairing } from "@/data/typography";
+import { getStyleById } from "@/data/styles";
 import { Star, ShoppingCart, Heart, Search, SlidersHorizontal } from "lucide-react";
 
 function usePreviewStyles() {
   const state = useWizardStore();
+  const style = getStyleById(state.styleId);
+  const styleIsDark = style ? isColorDark(style.tokens.bgBase) : false;
   const colorTheme = state.customBrandColor
-    ? generatePaletteFromBrand(state.customBrandColor, false)
+    ? generatePaletteFromBrand(state.customBrandColor, styleIsDark)
     : getColorTheme(state.colorThemeId);
   const fontPairing = getFontPairing(state.fontPairingId);
 

--- a/src/components/preview/templates/LandingPreview.tsx
+++ b/src/components/preview/templates/LandingPreview.tsx
@@ -2,7 +2,7 @@
 
 import { useWizardStore } from "@/store/wizard-store";
 import { RADIUS_MAP, SHADOW_MAP, DENSITY_MAP } from "@/types";
-import { getColorTheme, generatePaletteFromBrand } from "@/data/colors";
+import { getColorTheme, generatePaletteFromBrand, isColorDark } from "@/data/colors";
 import { getFontPairing } from "@/data/typography";
 import { getStyleById } from "@/data/styles";
 import { Star, ArrowRight, Check, Zap, Shield, Globe } from "lucide-react";
@@ -10,8 +10,9 @@ import { Star, ArrowRight, Check, Zap, Shield, Globe } from "lucide-react";
 function usePreviewStyles() {
   const state = useWizardStore();
   const style = getStyleById(state.styleId);
+  const styleIsDark = style ? isColorDark(style.tokens.bgBase) : false;
   const colorTheme = state.customBrandColor
-    ? generatePaletteFromBrand(state.customBrandColor, false)
+    ? generatePaletteFromBrand(state.customBrandColor, styleIsDark)
     : getColorTheme(state.colorThemeId);
   const fontPairing = getFontPairing(state.fontPairingId);
 

--- a/src/components/wizard/StyleCard.tsx
+++ b/src/components/wizard/StyleCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { StyleDefinition } from "@/types";
-import { getColorTheme } from "@/data/colors";
+import { getColorTheme, isColorDark } from "@/data/colors";
 import { cn } from "@/lib/utils";
 
 interface StyleCardProps {
@@ -19,13 +19,7 @@ export function StyleCard({ style, isSelected, onClick }: StyleCardProps) {
   const primary = colors?.primary ?? tokens.textPrimary;
   const accent = colors?.accent ?? tokens.textSecondary;
   const muted = colors?.muted ?? tokens.bgBase;
-  const isDark =
-    tokens.bgBase === "#000000" ||
-    tokens.bgBase === "#0d1117" ||
-    tokens.bgBase === "#0a0a0a" ||
-    tokens.bgBase === "#0f0f23" ||
-    tokens.bgBase === "#1a1a2e" ||
-    tokens.bgBase === "#0c0c0c";
+  const isDark = isColorDark(tokens.bgBase);
 
   return (
     <button
@@ -109,7 +103,7 @@ export function StyleCard({ style, isSelected, onClick }: StyleCardProps) {
                 border: `${tokens.borderWidth} solid ${tokens.borderColor}`,
                 borderRadius: tokens.radiusValue,
                 boxShadow: tokens.shadowValue,
-                backgroundColor: isDark ? "rgba(255,255,255,0.05)" : "rgba(0,0,0,0.02)",
+                backgroundColor: isDark ? "rgba(255,255,255,0.05)" : "rgba(0,0,0,0.03)",
               }}
             >
               <div

--- a/src/components/wizard/steps/ColorStep.tsx
+++ b/src/components/wizard/steps/ColorStep.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useWizardStore } from "@/store/wizard-store";
-import { getThemesForStyle, colorThemes, generatePaletteFromBrand } from "@/data/colors";
+import { getThemesForStyle, colorThemes, generatePaletteFromBrand, isColorDark } from "@/data/colors";
 import { getStyleById } from "@/data/styles";
 import { cn } from "@/lib/utils";
 import { useMemo, useState } from "react";
@@ -50,6 +50,7 @@ export function ColorStep() {
   const [brandInput, setBrandInput] = useState(customBrandColor || "#6366f1");
 
   const style = getStyleById(styleId);
+  const styleIsDark = style ? isColorDark(style.tokens.bgBase) : false;
   const recommended = useMemo(() => getThemesForStyle(styleId), [styleId]);
   const recommendedIds = useMemo(() => new Set(recommended.map((t) => t.id)), [recommended]);
   const otherThemes = useMemo(
@@ -148,7 +149,7 @@ export function ColorStep() {
 
         {/* Preview generated palette */}
         {customBrandColor && (() => {
-          const generated = generatePaletteFromBrand(customBrandColor, false);
+          const generated = generatePaletteFromBrand(customBrandColor, styleIsDark);
           return (
             <div className="flex h-8 rounded-lg overflow-hidden border border-border mt-2">
               <div className="flex-1" style={{ backgroundColor: generated.colors.background }} />

--- a/src/data/colors/index.ts
+++ b/src/data/colors/index.ts
@@ -1,2 +1,2 @@
 export { colorThemes, getColorTheme, getThemesForStyle } from "./palettes";
-export { generatePaletteFromBrand } from "./generator";
+export { generatePaletteFromBrand, isColorDark, relativeLuminance } from "./generator";

--- a/src/lib/prompt-engine.ts
+++ b/src/lib/prompt-engine.ts
@@ -1,6 +1,6 @@
 import type { WizardState, ToolTarget } from "@/types";
 import { getStyleById } from "@/data/styles";
-import { getColorTheme, generatePaletteFromBrand } from "@/data/colors";
+import { getColorTheme, generatePaletteFromBrand, isColorDark } from "@/data/colors";
 import { getFontPairing } from "@/data/typography";
 import { getLayout } from "@/data/layouts";
 import { RADIUS_MAP, SHADOW_MAP, DENSITY_MAP } from "@/types";
@@ -41,8 +41,10 @@ function buildStyleSection(state: WizardState): string {
 }
 
 function buildColorSection(state: WizardState): string {
+  const style = getStyleById(state.styleId);
+  const styleIsDark = style ? isColorDark(style.tokens.bgBase) : false;
   const colors = state.customBrandColor
-    ? generatePaletteFromBrand(state.customBrandColor, false)
+    ? generatePaletteFromBrand(state.customBrandColor, styleIsDark)
     : getColorTheme(state.colorThemeId);
 
   if (!colors) return "";


### PR DESCRIPTION
## Summary
- Added WCAG 2.1 contrast ratio checking to the brand color palette generator — primary color is now adjusted if it doesn't meet AA contrast (4.5:1) against the background
- Replaced all hardcoded dark-color hex lists with a proper luminance-based `isColorDark()` function
- Fixed all preview templates and ColorStep to detect dark styles using luminance instead of hardcoded `false`

Closes #16

## What changed
- `src/data/colors/generator.ts`: Added `relativeLuminance()`, `isColorDark()`, `contrastRatio()` utilities; added contrast verification in `generatePaletteFromBrand()`
- `src/data/colors/index.ts`: Exported new utility functions
- `src/components/preview/PreviewPanel.tsx`: Uses `isColorDark()` instead of hardcoded hex comparison
- `src/components/wizard/StyleCard.tsx`: Same — uses `isColorDark()` for card backgrounds
- `src/components/preview/templates/*.tsx`: All 3 templates use style-aware isDark detection
- `src/components/wizard/steps/ColorStep.tsx`: Palette preview uses style-aware isDark
- `src/lib/prompt-engine.ts`: Color section uses style-aware isDark

## How to test
1. Go to `/builder` → select Glassmorphism (dark style) → Colors step
2. Enter custom brand colors: `#ff0000`, `#00ff00`, `#ffffff`, `#888888`
3. Confirm all text remains legible in the preview
4. Switch to Neo-Brutalist (light) → try same brand colors
5. Confirm contrast is maintained in both light and dark contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)