### PR TITLE
Add desktop/mobile preview viewport toggle

### DIFF
--- a/src/components/preview/PreviewPanel.tsx
+++ b/src/components/preview/PreviewPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useWizardStore } from "@/store/wizard-store";
-import { styles, getStyleById } from "@/data/styles";
+import { getStyleById } from "@/data/styles";
 import { getColorTheme, generatePaletteFromBrand } from "@/data/colors";
 import { getFontPairing } from "@/data/typography";
 import { RADIUS_MAP, SHADOW_MAP } from "@/types";
@@ -84,42 +84,60 @@ export function PreviewPanel() {
         ? BlogPreview
         : LandingPreview;
 
-  return (
-    <div className="h-full overflow-auto" ref={containerRef}>
-      <div className="min-h-full" style={cssVars}>
+  const isMobile = state.previewViewport === "mobile";
+
+  const previewContent = (
+    <div className="min-h-full" style={cssVars}>
+      <div
+        className="relative min-h-screen"
+        style={{
+          backgroundColor: colors.background,
+          color: colors.foreground,
+          fontFamily: fontPairing
+            ? `'${fontPairing.body.family}', sans-serif`
+            : "sans-serif",
+        }}
+      >
+        {/* Grain overlay */}
+        {state.effects.grain && (
+          <div
+            className="pointer-events-none absolute inset-0 z-50 opacity-[0.04]"
+            style={{
+              backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E")`,
+            }}
+          />
+        )}
+
+        {/* Gradient overlay */}
+        {state.effects.gradient && (
+          <div
+            className="pointer-events-none absolute inset-0 z-40 opacity-30"
+            style={{
+              background: `radial-gradient(ellipse at 20% 50%, ${colors.primary}40 0%, transparent 50%), radial-gradient(ellipse at 80% 50%, ${colors.accent}30 0%, transparent 50%)`,
+            }}
+          />
+        )}
+
+        <PreviewTemplate />
+      </div>
+    </div>
+  );
+
+  if (isMobile) {
+    return (
+      <div className="h-full overflow-auto flex items-start justify-center bg-muted/50 p-6" ref={containerRef}>
         <div
-          className="relative min-h-screen"
-          style={{
-            backgroundColor: colors.background,
-            color: colors.foreground,
-            fontFamily: fontPairing
-              ? `'${fontPairing.body.family}', sans-serif`
-              : "sans-serif",
-          }}
+          className="relative w-[375px] min-h-[667px] rounded-[2rem] border-[8px] border-foreground/20 overflow-hidden shadow-2xl bg-background"
         >
-          {/* Grain overlay */}
-          {state.effects.grain && (
-            <div
-              className="pointer-events-none absolute inset-0 z-50 opacity-[0.04]"
-              style={{
-                backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E")`,
-              }}
-            />
-          )}
-
-          {/* Gradient overlay */}
-          {state.effects.gradient && (
-            <div
-              className="pointer-events-none absolute inset-0 z-40 opacity-30"
-              style={{
-                background: `radial-gradient(ellipse at 20% 50%, ${colors.primary}40 0%, transparent 50%), radial-gradient(ellipse at 80% 50%, ${colors.accent}30 0%, transparent 50%)`,
-              }}
-            />
-          )}
-
-          <PreviewTemplate />
+          {previewContent}
         </div>
       </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-auto" ref={containerRef}>
+      {previewContent}
     </div>
   );
 }

--- a/src/components/wizard/WizardShell.tsx
+++ b/src/components/wizard/WizardShell.tsx
@@ -12,7 +12,9 @@ import { PreviewPanel } from "@/components/preview/PreviewPanel";
 import { PromptOutput } from "@/components/output/PromptOutput";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Eye, Code2, ChevronLeft, ChevronRight } from "lucide-react";
+import { Eye, Code2, ChevronLeft, ChevronRight, Monitor, Smartphone } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { PreviewViewport } from "@/types";
 
 const steps = [
   PageTypeStep,
@@ -26,6 +28,8 @@ const steps = [
 export function WizardShell() {
   const currentStep = useWizardStore((s) => s.currentStep);
   const setStep = useWizardStore((s) => s.setStep);
+  const previewViewport = useWizardStore((s) => s.previewViewport);
+  const setPreviewViewport = useWizardStore((s) => s.setPreviewViewport);
   const [showPrompt, setShowPrompt] = useState(false);
   const [mobileView, setMobileView] = useState<"controls" | "preview">("controls");
 
@@ -114,8 +118,8 @@ export function WizardShell() {
 
         {/* Right: Live preview */}
         <div
-          className={`flex-1 bg-muted/30 overflow-hidden ${
-            mobileView === "controls" ? "hidden md:block" : "block"
+          className={`flex-1 bg-muted/30 overflow-hidden flex flex-col ${
+            mobileView === "controls" ? "hidden md:flex" : "flex"
           }`}
         >
           {/* Mobile back button */}
@@ -130,7 +134,33 @@ export function WizardShell() {
             </Button>
           </div>
 
-          <PreviewPanel />
+          {/* Preview toolbar with viewport toggle */}
+          <div className="hidden md:flex items-center justify-end p-2 border-b border-border bg-background/80 backdrop-blur-sm shrink-0">
+            <div className="flex items-center gap-1 bg-muted rounded-lg p-0.5">
+              {([
+                { id: "desktop" as PreviewViewport, icon: Monitor, label: "Desktop" },
+                { id: "mobile" as PreviewViewport, icon: Smartphone, label: "Mobile" },
+              ]).map(({ id, icon: Icon, label }) => (
+                <button
+                  key={id}
+                  onClick={() => setPreviewViewport(id)}
+                  title={label}
+                  className={cn(
+                    "flex items-center gap-1 px-2.5 py-1.5 rounded-md text-xs font-medium transition-all",
+                    previewViewport === id
+                      ? "bg-background text-foreground shadow-sm"
+                      : "text-muted-foreground hover:text-foreground"
+                  )}
+                >
+                  <Icon className="h-3.5 w-3.5" />
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex-1 overflow-hidden">
+            <PreviewPanel />
+          </div>
         </div>
       </div>
 

--- a/src/store/wizard-store.ts
+++ b/src/store/wizard-store.ts
@@ -1,9 +1,10 @@
 import { create } from "zustand";
-import type { WizardStore, PageType, LayoutId, DensityLevel, RadiusToken, ShadowToken, WizardState } from "@/types";
+import type { WizardStore, PageType, PreviewViewport, LayoutId, DensityLevel, RadiusToken, ShadowToken, WizardState } from "@/types";
 
 const initialState: WizardState = {
   currentStep: 0,
   pageType: "landing",
+  previewViewport: "desktop",
   styleId: "neo-brutalist",
   colorThemeId: "nb-acid",
   customBrandColor: null,
@@ -25,6 +26,7 @@ export const useWizardStore = create<WizardStore>((set) => ({
 
   setStep: (step: number) => set({ currentStep: step }),
   setPageType: (type: PageType) => set({ pageType: type }),
+  setPreviewViewport: (viewport: PreviewViewport) => set({ previewViewport: viewport }),
   setStyleId: (id: string) => set({ styleId: id }),
   setColorThemeId: (id: string) => set({ colorThemeId: id }),
   setCustomBrandColor: (color: string | null) => set({ customBrandColor: color }),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,8 @@ export type EffectToggle = "grain" | "blur" | "glow" | "gradient";
 
 export type ToolTarget = "v0" | "lovable" | "figma-make" | "claude-code" | "cursor";
 
+export type PreviewViewport = "desktop" | "mobile";
+
 export type FontCategory = "sans" | "serif" | "mono" | "display" | "rounded";
 
 export type LayoutId =
@@ -86,6 +88,7 @@ export interface LayoutOption {
 export interface WizardState {
   currentStep: number;
   pageType: PageType;
+  previewViewport: PreviewViewport;
   styleId: string;
   colorThemeId: string;
   customBrandColor: string | null;
@@ -105,6 +108,7 @@ export interface WizardState {
 export interface WizardActions {
   setStep: (step: number) => void;
   setPageType: (type: PageType) => void;
+  setPreviewViewport: (viewport: PreviewViewport) => void;
   setStyleId: (id: string) => void;
   setColorThemeId: (id: string) => void;
   setCustomBrandColor: (color: string | null) => void;


### PR DESCRIPTION
## Summary
- Adds a desktop/mobile viewport toggle above the preview panel (Monitor/Smartphone icons)
- Mobile preview renders inside a phone-frame container (375×667px) with rounded corners and device border
- Adds `previewViewport` state to Zustand store with `setPreviewViewport` action
- Toggle is desktop-only (hidden on mobile breakpoint where the full mobile UX applies)

Closes #9

## Changes
- `src/types/index.ts`: Added `PreviewViewport` type, updated `WizardState` and `WizardActions`
- `src/store/wizard-store.ts`: Added `previewViewport` initial state and setter
- `src/components/preview/PreviewPanel.tsx`: Phone-frame container for mobile viewport
- `src/components/wizard/WizardShell.tsx`: Viewport toggle toolbar above preview

## Test plan
- [ ] Navigate to builder, confirm viewport toggle visible above preview
- [ ] Click Mobile icon — preview shows phone-frame container
- [ ] Click Desktop icon — preview returns to full-width
- [ ] Test with all 3 page types (landing, ecommerce, blog)
- [ ] Verify toggle is hidden on mobile screen widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)