### PR TITLE
Enhance style cards with actual colors and visual homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import {
   Eye,
   Zap,
 } from "lucide-react";
+import { StyleShowcase } from "@/components/home/StyleShowcase";
 
 const tools = [
   { name: "v0", color: "bg-neutral-900 text-white" },
@@ -17,28 +18,6 @@ const tools = [
   { name: "Cursor", color: "bg-green-600 text-white" },
 ];
 
-const styleNames = [
-  "Neo-Brutalist",
-  "Glassmorphism",
-  "Swiss International",
-  "Cinematic Noir",
-  "Claymorphism",
-  "Acid Cyber Y2K",
-  "Bento Grid",
-  "Clean SaaS",
-  "Retro Futurism",
-  "Bold Minimalist",
-  "Organic Natural",
-  "Scrapbook Collage",
-  "Corporate Modern",
-  "Gradient Mesh",
-  "Neumorphism",
-  "Editorial Magazine",
-  "Monochrome Minimal",
-  "Playful Kawaii",
-  "Luxury Premium",
-  "Terminal Hacker",
-];
 
 const steps = [
   {
@@ -168,7 +147,7 @@ export default function HomePage() {
 
       {/* Style showcase */}
       <section className="py-24 px-6">
-        <div className="max-w-4xl mx-auto text-center">
+        <div className="max-w-5xl mx-auto text-center">
           <h2 className="text-2xl md:text-3xl font-bold mb-4">
             20 curated visual styles
           </h2>
@@ -176,16 +155,7 @@ export default function HomePage() {
             From Neo-Brutalist to Glassmorphism, each style comes with curated
             colors, fonts, and tokens ready to go.
           </p>
-          <div className="flex flex-wrap justify-center gap-2">
-            {styleNames.map((style) => (
-              <span
-                key={style}
-                className="px-3 py-1.5 text-sm font-medium border border-border rounded-lg hover:border-primary/40 hover:bg-primary/5 transition-colors"
-              >
-                {style}
-              </span>
-            ))}
-          </div>
+          <StyleShowcase />
         </div>
       </section>
 

--- a/src/components/home/StyleShowcase.tsx
+++ b/src/components/home/StyleShowcase.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { styles } from "@/data/styles";
+import { getColorTheme } from "@/data/colors";
+import Link from "next/link";
+
+export function StyleShowcase() {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+      {styles.map((style) => {
+        const theme = getColorTheme(style.defaults.colorThemeId);
+        const colors = theme?.colors;
+        const { tokens } = style;
+
+        const primary = colors?.primary ?? tokens.textPrimary;
+        const accent = colors?.accent ?? tokens.textSecondary;
+        const isDark =
+          tokens.bgBase === "#000000" ||
+          tokens.bgBase === "#0d1117" ||
+          tokens.bgBase === "#0a0a0a" ||
+          tokens.bgBase === "#0f0f23" ||
+          tokens.bgBase === "#1a1a2e" ||
+          tokens.bgBase === "#0c0c0c";
+
+        return (
+          <Link
+            key={style.id}
+            href="/builder"
+            className="group flex flex-col rounded-lg border border-border overflow-hidden hover:border-primary/40 hover:shadow-md transition-all"
+          >
+            {/* Mini preview */}
+            <div
+              className="h-20 p-2.5 flex flex-col gap-1 relative overflow-hidden"
+              style={{ backgroundColor: tokens.bgBase }}
+            >
+              {style.defaults.effects.includes("gradient") && (
+                <div
+                  className="absolute inset-0 opacity-25"
+                  style={{
+                    background: `radial-gradient(ellipse at 30% 50%, ${primary}40 0%, transparent 60%)`,
+                  }}
+                />
+              )}
+              {/* Mini heading */}
+              <div className="relative flex flex-col gap-0.5 flex-1 justify-center">
+                <div
+                  className="h-1.5 w-3/4 rounded-sm"
+                  style={{ backgroundColor: tokens.textPrimary, opacity: 0.85 }}
+                />
+                <div
+                  className="h-1 w-1/2 rounded-sm"
+                  style={{ backgroundColor: tokens.textSecondary, opacity: 0.45 }}
+                />
+              </div>
+              {/* Mini cards */}
+              <div className="relative flex gap-1">
+                {[primary, accent].map((color, i) => (
+                  <div
+                    key={i}
+                    className="flex-1 h-5"
+                    style={{
+                      border: `${tokens.borderWidth} solid ${tokens.borderColor}`,
+                      borderRadius: tokens.radiusValue,
+                      boxShadow: tokens.shadowValue,
+                      backgroundColor: isDark
+                        ? "rgba(255,255,255,0.05)"
+                        : "rgba(0,0,0,0.02)",
+                    }}
+                  >
+                    <div
+                      className="h-1 mx-1 mt-1 rounded-full opacity-50"
+                      style={{ backgroundColor: color }}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+            {/* Label */}
+            <div className="p-2 bg-card">
+              <p className="text-xs font-semibold truncate">{style.name}</p>
+            </div>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/wizard/StyleCard.tsx
+++ b/src/components/wizard/StyleCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { StyleDefinition } from "@/types";
+import { getColorTheme } from "@/data/colors";
 import { cn } from "@/lib/utils";
 
 interface StyleCardProps {
@@ -11,6 +12,20 @@ interface StyleCardProps {
 
 export function StyleCard({ style, isSelected, onClick }: StyleCardProps) {
   const { tokens } = style;
+  const theme = getColorTheme(style.defaults.colorThemeId);
+  const colors = theme?.colors;
+
+  // Use theme colors for more vivid previews, fallback to tokens
+  const primary = colors?.primary ?? tokens.textPrimary;
+  const accent = colors?.accent ?? tokens.textSecondary;
+  const muted = colors?.muted ?? tokens.bgBase;
+  const isDark =
+    tokens.bgBase === "#000000" ||
+    tokens.bgBase === "#0d1117" ||
+    tokens.bgBase === "#0a0a0a" ||
+    tokens.bgBase === "#0f0f23" ||
+    tokens.bgBase === "#1a1a2e" ||
+    tokens.bgBase === "#0c0c0c";
 
   return (
     <button
@@ -18,23 +33,39 @@ export function StyleCard({ style, isSelected, onClick }: StyleCardProps) {
       className={cn(
         "relative flex flex-col w-full rounded-lg border-2 overflow-hidden text-left transition-all",
         isSelected
-          ? "border-primary ring-2 ring-primary/20"
+          ? "border-primary ring-2 ring-primary/30"
           : "border-border hover:border-primary/40"
       )}
     >
+      {/* Selected indicator */}
+      {isSelected && (
+        <div className="absolute top-1.5 right-1.5 z-10 w-5 h-5 rounded-full bg-primary flex items-center justify-center">
+          <svg className="w-3 h-3 text-primary-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+      )}
+
       {/* Mini preview */}
       <div
-        className="h-28 p-3 flex flex-col gap-1.5"
-        style={{
-          backgroundColor: tokens.bgBase,
-          borderRadius: tokens.radiusValue,
-        }}
+        className="h-28 p-3 flex flex-col gap-1.5 relative overflow-hidden"
+        style={{ backgroundColor: tokens.bgBase }}
       >
+        {/* Subtle gradient hint for styles that use gradients */}
+        {style.defaults.effects.includes("gradient") && (
+          <div
+            className="absolute inset-0 opacity-30"
+            style={{
+              background: `radial-gradient(ellipse at 30% 50%, ${primary}40 0%, transparent 60%)`,
+            }}
+          />
+        )}
+
         {/* Mini nav */}
-        <div className="flex items-center gap-1.5">
+        <div className="relative flex items-center gap-1.5">
           <div
             className="h-1.5 w-8 rounded-full"
-            style={{ backgroundColor: tokens.textPrimary, opacity: 0.8 }}
+            style={{ backgroundColor: primary, opacity: 0.9 }}
           />
           <div className="flex-1" />
           <div
@@ -48,7 +79,7 @@ export function StyleCard({ style, isSelected, onClick }: StyleCardProps) {
         </div>
 
         {/* Mini hero */}
-        <div className="flex-1 flex flex-col justify-center gap-1">
+        <div className="relative flex-1 flex flex-col justify-center gap-1">
           <div
             className="h-2 w-3/4 rounded-sm"
             style={{ backgroundColor: tokens.textPrimary, opacity: 0.9 }}
@@ -57,24 +88,35 @@ export function StyleCard({ style, isSelected, onClick }: StyleCardProps) {
             className="h-1.5 w-1/2 rounded-sm"
             style={{ backgroundColor: tokens.textSecondary, opacity: 0.5 }}
           />
+          {/* Mini CTA button */}
+          <div
+            className="h-3 w-14 mt-0.5"
+            style={{
+              backgroundColor: primary,
+              borderRadius: tokens.radiusValue,
+              border: `${tokens.borderWidth} solid ${tokens.borderColor}`,
+            }}
+          />
         </div>
 
         {/* Mini cards */}
-        <div className="flex gap-1.5">
-          {[1, 2, 3].map((i) => (
+        <div className="relative flex gap-1.5">
+          {[primary, accent, muted].map((color, i) => (
             <div
               key={i}
-              className="flex-1 h-8"
+              className="flex-1 h-8 flex flex-col justify-end p-1"
               style={{
                 border: `${tokens.borderWidth} solid ${tokens.borderColor}`,
                 borderRadius: tokens.radiusValue,
                 boxShadow: tokens.shadowValue,
-                backgroundColor:
-                  tokens.bgBase === "#000000" || tokens.bgBase === "#0d1117" || tokens.bgBase === "#0a0a0a" || tokens.bgBase === "#0f0f23" || tokens.bgBase === "#1a1a2e" || tokens.bgBase === "#0c0c0c"
-                    ? "rgba(255,255,255,0.05)"
-                    : "rgba(0,0,0,0.03)",
+                backgroundColor: isDark ? "rgba(255,255,255,0.05)" : "rgba(0,0,0,0.02)",
               }}
-            />
+            >
+              <div
+                className="h-1 w-full rounded-full opacity-60"
+                style={{ backgroundColor: color }}
+              />
+            </div>
           ))}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- **StyleCard**: Enhanced mini-preview with actual style colors — colored accent bars in cards, CTA button preview, gradient hints for gradient styles, and a checkmark badge overlay for selected state
- **Homepage**: Replaced text-only style name pills with a responsive grid of visual mini-cards showing each style's actual tokens (background, borders, shadows, radius, colors)
- Created new `StyleShowcase` client component island for the homepage

Closes #13, Closes #6

## Changes
- `src/components/wizard/StyleCard.tsx`: Use default color theme colors (primary, accent, muted) in mini-preview, add gradient overlay for gradient styles, add selected checkmark badge
- `src/components/home/StyleShowcase.tsx`: New client component with visual mini-cards grid for all 20 styles
- `src/app/page.tsx`: Import StyleShowcase, remove static `styleNames` array, widen container to `max-w-5xl`

## Test plan
- [ ] Go to Style step in builder — cards show colorful, distinctive previews per style
- [ ] Select different styles — checkmark badge appears on selected card
- [ ] Visit homepage — "20 curated styles" section shows visual grid, not text pills
- [ ] Each homepage card visually reflects its style (dark bg for dark styles, thick borders for brutalist, etc.)
- [ ] Click a homepage style card — navigates to builder

🤖 Generated with [Claude Code](https://claude.com/claude-code)