### PR TITLE
Remove Layout wizard tab and layout section from prompt output

### DIFF
--- a/src/components/output/PromptOutput.tsx
+++ b/src/components/output/PromptOutput.tsx
@@ -41,7 +41,6 @@ export function PromptOutput({ onClose }: PromptOutputProps) {
     state.styleId && "style",
     state.colorThemeId && "colors",
     state.fontPairingId && "typography",
-    state.layoutId && "layout",
     "effects",
   ].filter(Boolean);
 

--- a/src/components/wizard/WizardShell.tsx
+++ b/src/components/wizard/WizardShell.tsx
@@ -5,7 +5,6 @@ import { WizardSidebar } from "./WizardSidebar";
 import { StyleStep } from "./steps/StyleStep";
 import { ColorStep } from "./steps/ColorStep";
 import { TypographyStep } from "./steps/TypographyStep";
-import { LayoutStep } from "./steps/LayoutStep";
 import { EffectsStep } from "./steps/EffectsStep";
 import { PreviewPanel } from "@/components/preview/PreviewPanel";
 import { PromptOutput } from "@/components/output/PromptOutput";
@@ -19,7 +18,6 @@ const steps = [
   StyleStep,
   ColorStep,
   TypographyStep,
-  LayoutStep,
   EffectsStep,
 ];
 

--- a/src/components/wizard/WizardSidebar.tsx
+++ b/src/components/wizard/WizardSidebar.tsx
@@ -7,7 +7,6 @@ import {
   Palette,
   Paintbrush,
   Type,
-  LayoutGrid,
   Sparkles,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -17,7 +16,6 @@ const iconMap = {
   Palette,
   Paintbrush,
   Type,
-  LayoutGrid,
   Sparkles,
 } as const;
 

--- a/src/lib/prompt-engine.ts
+++ b/src/lib/prompt-engine.ts
@@ -2,7 +2,6 @@ import type { WizardState, ToolTarget } from "@/types";
 import { getStyleById } from "@/data/styles";
 import { getColorTheme, generatePaletteFromBrand, isColorDark } from "@/data/colors";
 import { getFontPairing } from "@/data/typography";
-import { getLayout } from "@/data/layouts";
 import { RADIUS_MAP, SHADOW_MAP, DENSITY_MAP } from "@/types";
 
 const DENSITY_LABELS = {
@@ -63,26 +62,6 @@ function buildTypographySection(state: WizardState): string {
 - Headings: ${fonts.heading.family} (weight: ${fonts.heading.weight}) — use for all h1-h3 elements, hero text, and section titles
 - Body: ${fonts.body.family} (weight: ${fonts.body.weight}) — use for paragraphs, descriptions, and UI text
 - Import from Google Fonts: ${fonts.heading.family}${fonts.heading.family !== fonts.body.family ? ` and ${fonts.body.family}` : ""}`;
-}
-
-function buildLayoutSection(state: WizardState): string {
-  const layout = getLayout(state.layoutId);
-  if (!layout) return "";
-
-  const layoutInstructions: Record<string, string> = {
-    "hero-stacked":
-      "Use a Hero + Stacked Sections layout: Start with a prominent hero section (large headline, subtext, CTA button), followed by vertically stacked content sections (features grid, testimonials, pricing, footer).",
-    "bento-grid":
-      "Use a Bento Grid layout: Organize content in a modular grid of cards with varying sizes (some 1x1, some 2x1, some 1x2). Cards should have uniform border radius and consistent gaps, inspired by Apple's product pages.",
-    "single-column":
-      "Use a Single Column layout: Center all content in a narrow column (max-width ~680px). This editorial style prioritizes readability with ample margins and clear visual hierarchy.",
-    "sidebar-content":
-      "Use a Sidebar + Content layout: Fixed left sidebar (240px) with navigation links, and a main content area on the right. The sidebar should have a subtle border or background differentiation.",
-    "full-width":
-      "Use a Full-width Sections layout: Each section spans the full viewport width edge-to-edge. Alternate between content sections with different background colors or treatments for visual rhythm.",
-  };
-
-  return `**Layout:**\n${layoutInstructions[state.layoutId] || layout.description}`;
 }
 
 function buildSpacingSection(state: WizardState): string {
@@ -181,7 +160,6 @@ export function generatePrompt(state: WizardState, tool: ToolTarget): string {
     buildStyleSection(state),
     buildColorSection(state),
     buildTypographySection(state),
-    buildLayoutSection(state),
     buildSpacingSection(state),
     buildEffectsSection(state),
     buildToolConstraints(tool),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -149,6 +149,5 @@ export const WIZARD_STEPS = [
   { id: 0, label: "Style", icon: "Palette" },
   { id: 1, label: "Colors", icon: "Paintbrush" },
   { id: 2, label: "Typography", icon: "Type" },
-  { id: 3, label: "Layout", icon: "LayoutGrid" },
-  { id: 4, label: "Effects", icon: "Sparkles" },
+  { id: 3, label: "Effects", icon: "Sparkles" },
 ] as const;


### PR DESCRIPTION
The Layout step had no effect on the live preview and added unnecessary friction to the wizard flow. The layout section has also been removed from generated prompts.