### PR TITLE
redesign: dark editorial homepage with animated style demo

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -124,3 +124,54 @@
     @apply bg-background text-foreground overflow-x-hidden;
   }
 }
+
+/* Homepage animations */
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes pulse-subtle {
+  0%, 100% { opacity: 0.4; }
+  50% { opacity: 0.7; }
+}
+
+.animate-fade-in-up {
+  animation: fade-in-up 0.8s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.animate-fade-in {
+  animation: fade-in 0.6s ease both;
+}
+
+.animation-delay-100 { animation-delay: 100ms; }
+.animation-delay-200 { animation-delay: 200ms; }
+.animation-delay-300 { animation-delay: 300ms; }
+.animation-delay-400 { animation-delay: 400ms; }
+.animation-delay-500 { animation-delay: 500ms; }
+.animation-delay-600 { animation-delay: 600ms; }
+.animation-delay-700 { animation-delay: 700ms; }
+
+/* Subtle grid background for dark sections */
+.grid-bg {
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.025) 1px, transparent 1px);
+  background-size: 64px 64px;
+}
+
+/* Font utility */
+.font-serif-display {
+  font-family: var(--font-instrument-serif), Georgia, serif;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Instrument_Serif } from "next/font/google";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
@@ -13,6 +13,13 @@ const geistSans = Geist({
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+});
+
+const instrumentSerif = Instrument_Serif({
+  variable: "--font-instrument-serif",
+  subsets: ["latin"],
+  weight: "400",
+  style: ["normal", "italic"],
 });
 
 export const metadata: Metadata = {
@@ -36,7 +43,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} ${instrumentSerif.variable} antialiased`}
       >
         <TooltipProvider>{children}</TooltipProvider>
         <Analytics />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,304 +1,316 @@
 import Link from "next/link";
-import {
-  ArrowRight,
-  Palette,
-  Sparkles,
-  Copy,
-  Wand2,
-  Eye,
-  Zap,
-  ChevronRight,
-} from "lucide-react";
+import { ArrowRight, Sparkles } from "lucide-react";
+import { HeroStyleDemo } from "@/components/home/HeroStyleDemo";
 import { StyleShowcase } from "@/components/home/StyleShowcase";
 import { toolLogos } from "@/components/shared/ToolLogos";
 import type { ToolTarget } from "@/types";
 
-const toolOrder: ToolTarget[] = ["v0", "lovable", "figma-make", "claude-code", "cursor"];
-
-const steps = [
-  {
-    icon: Palette,
-    title: "Pick your style",
-    description:
-      "Choose from 20 curated visual styles — Neo-Brutalist, Glassmorphism, Swiss, and more.",
-    color: "from-violet-500/20 to-violet-500/5",
-    iconBg: "bg-violet-500/15",
-    iconColor: "text-violet-600",
-  },
-  {
-    icon: Wand2,
-    title: "Customize everything",
-    description:
-      "Fine-tune colors, typography, layout, spacing, and effects to match your vision.",
-    color: "from-blue-500/20 to-blue-500/5",
-    iconBg: "bg-blue-500/15",
-    iconColor: "text-blue-600",
-  },
-  {
-    icon: Eye,
-    title: "See it live",
-    description:
-      "Watch your choices come alive in a real-time preview across landing, e-commerce, and blog templates.",
-    color: "from-emerald-500/20 to-emerald-500/5",
-    iconBg: "bg-emerald-500/15",
-    iconColor: "text-emerald-600",
-  },
-  {
-    icon: Copy,
-    title: "Copy your prompt",
-    description:
-      "Get a tool-specific prompt optimized for your chosen AI coding assistant.",
-    color: "from-amber-500/20 to-amber-500/5",
-    iconBg: "bg-amber-500/15",
-    iconColor: "text-amber-600",
-  },
+const toolOrder: ToolTarget[] = [
+  "v0",
+  "lovable",
+  "figma-make",
+  "claude-code",
+  "cursor",
 ];
 
 export default function HomePage() {
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      {/* Nav */}
-      <nav className="flex items-center justify-between px-6 py-4 border-b border-border">
+    <div className="min-h-screen bg-[#09090B] text-[#FAFAF9] overflow-x-hidden">
+      {/* ── Nav ── */}
+      <nav className="flex items-center justify-between px-6 lg:px-10 py-5">
         <div className="flex items-center gap-2">
-          <Sparkles className="h-5 w-5 text-primary" />
-          <span className="font-bold text-lg tracking-tight">
-            Palette<span className="text-primary">Kit</span>
+          <Sparkles className="h-4 w-4 text-amber-400" />
+          <span className="font-semibold text-sm tracking-tight text-[#E4E4E7]">
+            Palette<span className="text-amber-400">Kit</span>
           </span>
         </div>
         <Link
           href="/builder"
-          className="inline-flex items-center gap-2 px-4 py-2 text-sm font-semibold bg-primary text-primary-foreground rounded-lg hover:opacity-90 transition-opacity"
+          className="inline-flex items-center gap-2 px-4 py-2 text-xs font-semibold text-[#09090B] bg-[#FAFAF9] rounded-md hover:bg-[#E4E4E7] transition-colors"
         >
           Open Builder
-          <ArrowRight className="h-4 w-4" />
+          <ArrowRight className="h-3 w-3" />
         </Link>
       </nav>
 
-      {/* Hero */}
-      <section className="py-24 px-6 text-center">
-        <div className="max-w-3xl mx-auto">
-          <div className="inline-flex items-center gap-2 px-3 py-1.5 mb-6 text-xs font-semibold bg-primary/10 text-primary rounded-full">
-            <Zap className="h-3 w-3" />
-            Turn visual taste into pixel-perfect prompts
-          </div>
-          <h1 className="text-4xl md:text-6xl font-bold tracking-tight mb-6 leading-[1.1]">
-            Your design vision,
-            <br />
-            their pixel-perfect code
-          </h1>
-          <p className="text-lg text-muted-foreground mb-8 max-w-xl mx-auto">
-            AI tools produce generic output because prompts lack design specifics.
-            PaletteKit lets you visually define your style, then generates
-            detailed, tool-optimized prompts that produce exactly what you envision.
-          </p>
-          <div className="flex items-center justify-center gap-4">
-            <Link
-              href="/builder"
-              className="inline-flex items-center gap-2 px-6 py-3 text-sm font-semibold bg-primary text-primary-foreground rounded-lg hover:opacity-90 transition-opacity"
-            >
-              Start Building
-              <ArrowRight className="h-4 w-4" />
-            </Link>
-          </div>
-
-          {/* Tool logos */}
-          <div className="flex items-center justify-center gap-4 mt-8">
-            <span className="text-xs text-muted-foreground mr-1">
-              Optimized for:
-            </span>
-            {toolOrder.map((id) => {
-              const Logo = toolLogos[id];
-              return <Logo key={id} className="h-7 w-7" />;
-            })}
-          </div>
+      {/* ── Hero ── */}
+      <section className="relative grid-bg">
+        {/* Ambient glow */}
+        <div className="absolute inset-0 pointer-events-none overflow-hidden">
+          <div className="absolute top-[-20%] right-[-10%] w-[60%] h-[80%] rounded-full bg-amber-500/[0.04] blur-[100px]" />
+          <div className="absolute bottom-[-10%] left-[-5%] w-[40%] h-[50%] rounded-full bg-violet-500/[0.03] blur-[80px]" />
         </div>
-      </section>
 
-      {/* How it works */}
-      <section className="py-24 px-6 relative overflow-hidden">
-        <div className="absolute inset-0 bg-gradient-to-b from-muted/50 via-muted/20 to-transparent" />
-        <div className="max-w-5xl mx-auto relative">
-          <div className="text-center mb-16">
-            <div className="inline-flex items-center gap-2 px-3 py-1.5 mb-4 text-xs font-semibold bg-primary/10 text-primary rounded-full">
-              4 simple steps
+        <div className="relative max-w-7xl mx-auto px-6 lg:px-10 pt-16 sm:pt-20 pb-20 sm:pb-28">
+          <div className="lg:grid lg:grid-cols-[1.15fr_0.85fr] gap-12 xl:gap-20 items-center">
+            {/* Left: Copy */}
+            <div>
+              <p className="animate-fade-in-up text-xs font-mono tracking-[0.2em] uppercase text-[#71717A] mb-6">
+                Design-to-prompt generator
+              </p>
+
+              <h1 className="animate-fade-in-up animation-delay-100 font-serif-display text-[clamp(2.5rem,6vw,4.5rem)] leading-[1.08] mb-7 tracking-[-0.01em]">
+                AI can code anything.
+                <br />
+                It just can&rsquo;t read
+                <br />
+                <em className="text-amber-400">your mind.</em>
+              </h1>
+
+              <p className="animate-fade-in-up animation-delay-200 text-base sm:text-lg text-[#A1A1AA] max-w-lg mb-10 leading-relaxed">
+                You know exactly what you want. Your prompt doesn&rsquo;t say
+                it. PaletteKit lets you visually define your style &mdash;
+                colors, type, spacing, effects &mdash; then generates a prompt
+                your AI tool actually understands.
+              </p>
+
+              <div className="animate-fade-in-up animation-delay-300 flex flex-wrap items-center gap-4 mb-10">
+                <Link
+                  href="/builder"
+                  className="inline-flex items-center gap-2.5 px-6 py-3 text-sm font-semibold text-[#09090B] bg-[#FAFAF9] rounded-md hover:bg-[#E4E4E7] transition-colors"
+                >
+                  Start building
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+                <span className="text-xs text-[#52525B]">
+                  Free &middot; No signup &middot; In-browser
+                </span>
+              </div>
+
+              {/* Tool logos */}
+              <div className="animate-fade-in-up animation-delay-400 flex items-center gap-3">
+                <span className="text-[10px] font-mono uppercase tracking-wider text-[#52525B] mr-1">
+                  Works with
+                </span>
+                {toolOrder.map((id) => {
+                  const Logo = toolLogos[id];
+                  return (
+                    <Logo
+                      key={id}
+                      className="h-6 w-6 opacity-50 hover:opacity-80 transition-opacity"
+                    />
+                  );
+                })}
+              </div>
             </div>
-            <h2 className="text-2xl md:text-4xl font-bold mb-4">
-              How it works
-            </h2>
-            <p className="text-muted-foreground max-w-md mx-auto">
-              From vision to prompt in under a minute. No design skills needed.
-            </p>
-          </div>
 
-          {/* Desktop: horizontal flow with cards */}
-          <div className="hidden md:grid md:grid-cols-4 gap-4">
-            {steps.map((step, i) => (
-              <div key={step.title} className="relative group">
-                {/* Connector arrow */}
-                {i < steps.length - 1 && (
-                  <div className="absolute top-12 -right-2 z-10">
-                    <ChevronRight className="h-4 w-4 text-muted-foreground/40" />
-                  </div>
-                )}
-
-                <div className={`h-full rounded-2xl border border-border bg-gradient-to-b ${step.color} p-6 transition-all hover:shadow-lg hover:-translate-y-1`}>
-                  {/* Step number */}
-                  <div className="flex items-center justify-between mb-5">
-                    <div className={`flex items-center justify-center w-12 h-12 rounded-xl ${step.iconBg}`}>
-                      <step.icon className={`h-6 w-6 ${step.iconColor}`} />
-                    </div>
-                    <span className="text-4xl font-black text-foreground/[0.06]">
-                      {i + 1}
-                    </span>
-                  </div>
-
-                  <h3 className="font-bold text-base mb-2">{step.title}</h3>
-                  <p className="text-sm text-muted-foreground leading-relaxed">
-                    {step.description}
-                  </p>
-                </div>
-              </div>
-            ))}
-          </div>
-
-          {/* Mobile: vertical timeline */}
-          <div className="md:hidden">
-            {steps.map((step, i) => (
-              <div key={step.title} className="flex gap-4 mb-1 last:mb-0">
-                {/* Timeline */}
-                <div className="flex flex-col items-center">
-                  <div className={`flex items-center justify-center w-10 h-10 rounded-xl ${step.iconBg} shrink-0 z-10`}>
-                    <step.icon className={`h-5 w-5 ${step.iconColor}`} />
-                  </div>
-                  {i < steps.length - 1 && (
-                    <div className="w-px flex-1 bg-border my-1" />
-                  )}
-                </div>
-
-                {/* Content */}
-                <div className="pb-8">
-                  <div className="flex items-center gap-2 mb-1">
-                    <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
-                      Step {i + 1}
-                    </span>
-                  </div>
-                  <h3 className="font-bold mb-1">{step.title}</h3>
-                  <p className="text-sm text-muted-foreground leading-relaxed">
-                    {step.description}
-                  </p>
-                </div>
-              </div>
-            ))}
+            {/* Right: Live demo */}
+            <div className="mt-14 lg:mt-0">
+              <HeroStyleDemo />
+            </div>
           </div>
         </div>
       </section>
 
-      {/* Style showcase */}
-      <section className="py-24 px-6">
-        <div className="max-w-5xl mx-auto text-center">
-          <h2 className="text-2xl md:text-3xl font-bold mb-4">
-            20 curated visual styles
-          </h2>
-          <p className="text-muted-foreground mb-10">
-            From Neo-Brutalist to Glassmorphism, each style comes with curated
-            colors, fonts, and tokens ready to go.
+      {/* ── Divider ── */}
+      <div className="max-w-7xl mx-auto px-6 lg:px-10">
+        <div className="h-px bg-gradient-to-r from-transparent via-[#27272A] to-transparent" />
+      </div>
+
+      {/* ── The Prompt Gap ── */}
+      <section className="py-20 sm:py-28 px-6 lg:px-10">
+        <div className="max-w-4xl mx-auto">
+          <p className="text-xs font-mono tracking-[0.2em] uppercase text-[#52525B] mb-4 text-center">
+            The problem
           </p>
-          <StyleShowcase />
-        </div>
-      </section>
-
-      {/* The problem — Semantic Translation Gap */}
-      <section className="py-24 px-6 bg-muted/30">
-        <div className="max-w-3xl mx-auto">
-          <h2 className="text-2xl md:text-3xl font-bold text-center mb-12">
-            The Semantic Translation Gap
+          <h2 className="text-2xl sm:text-3xl md:text-4xl font-serif-display text-center mb-4 leading-tight">
+            You say &ldquo;clean and modern.&rdquo;
+            <br />
+            <span className="text-[#52525B]">
+              AI hears &ldquo;gray boxes.&rdquo;
+            </span>
           </h2>
-          <div className="grid md:grid-cols-[1fr_auto_1fr] gap-4 md:gap-6 items-stretch">
+          <p className="text-sm text-[#71717A] text-center max-w-md mx-auto mb-14">
+            Vague design language produces vague output. PaletteKit makes your
+            intent precise.
+          </p>
+
+          <div className="grid md:grid-cols-[1fr_auto_1fr] gap-5 md:gap-6 items-stretch">
             {/* Before */}
-            <div className="p-6 bg-background rounded-xl border border-destructive/30 flex flex-col">
-              <p className="text-xs font-bold text-destructive uppercase tracking-wider mb-3">
-                Vague prompt
-              </p>
-              <p className="text-sm italic text-muted-foreground mb-4">
-                &quot;Make it look edgy and modern with a dark theme&quot;
-              </p>
-              {/* Mini generic UI mockup */}
-              <div className="mt-auto rounded-lg border border-border bg-neutral-100 p-3 space-y-2">
-                <div className="h-2 w-20 bg-neutral-300 rounded" />
-                <div className="flex gap-2">
-                  <div className="h-8 flex-1 bg-neutral-200 rounded" />
-                  <div className="h-8 flex-1 bg-neutral-200 rounded" />
-                </div>
-                <div className="h-3 w-full bg-neutral-200 rounded" />
-                <div className="h-3 w-3/4 bg-neutral-200 rounded" />
+            <div className="rounded-lg border border-[#27272A] bg-[#111113] overflow-hidden flex flex-col">
+              <div className="px-5 py-3 border-b border-[#27272A] flex items-center gap-2">
+                <div className="w-2 h-2 rounded-full bg-red-500/60" />
+                <span className="text-[10px] font-mono uppercase tracking-wider text-[#71717A]">
+                  Your prompt
+                </span>
               </div>
-              <p className="text-xs text-destructive mt-3">
-                Result: Generic dark UI with default shadows
-              </p>
+              <div className="p-5 flex-1 flex flex-col">
+                <p className="text-sm italic text-[#71717A] mb-5 leading-relaxed">
+                  &ldquo;Make it look edgy and modern with a dark theme&rdquo;
+                </p>
+                {/* Generic mockup */}
+                <div className="mt-auto rounded-md border border-[#27272A] bg-[#1a1a1d] p-3 space-y-2">
+                  <div className="h-2 w-20 bg-[#3f3f46] rounded" />
+                  <div className="flex gap-2">
+                    <div className="h-8 flex-1 bg-[#27272A] rounded" />
+                    <div className="h-8 flex-1 bg-[#27272A] rounded" />
+                  </div>
+                  <div className="h-2.5 w-full bg-[#27272A] rounded" />
+                  <div className="h-2.5 w-3/4 bg-[#27272A] rounded" />
+                </div>
+                <p className="text-[10px] text-[#52525B] mt-3 font-mono">
+                  Result: Generic. Forgettable. Not what you meant.
+                </p>
+              </div>
             </div>
 
             {/* Arrow */}
             <div className="hidden md:flex items-center justify-center">
-              <div className="flex flex-col items-center gap-1">
-                <ArrowRight className="h-6 w-6 text-primary" />
-                <span className="text-[10px] font-semibold text-primary uppercase tracking-wider">PaletteKit</span>
+              <div className="flex flex-col items-center gap-2">
+                <div className="h-8 w-px bg-gradient-to-b from-transparent via-amber-400/40 to-transparent" />
+                <div className="w-8 h-8 rounded-full border border-amber-400/30 flex items-center justify-center">
+                  <ArrowRight className="h-3.5 w-3.5 text-amber-400" />
+                </div>
+                <div className="h-8 w-px bg-gradient-to-b from-transparent via-amber-400/40 to-transparent" />
               </div>
             </div>
             <div className="md:hidden flex items-center justify-center py-1">
-              <ArrowRight className="h-5 w-5 text-primary rotate-90" />
+              <ArrowRight className="h-4 w-4 text-amber-400 rotate-90" />
             </div>
 
             {/* After */}
-            <div className="p-6 bg-background rounded-xl border border-green-500/30 flex flex-col">
-              <p className="text-xs font-bold text-green-600 uppercase tracking-wider mb-3">
-                PaletteKit output
-              </p>
-              <p className="text-sm italic text-muted-foreground mb-4">
-                &quot;Neo-Brutalist: 3px black borders, hard 4px offset shadows, 0px radius. Palette: bg #000, primary #CCFF00...&quot;
-              </p>
-              {/* Mini styled UI mockup */}
-              <div className="mt-auto rounded-none border-2 border-black bg-black p-3 space-y-2">
-                <div className="h-2 w-20 bg-[#CCFF00] rounded-none" />
-                <div className="flex gap-2">
-                  <div className="h-8 flex-1 bg-[#CCFF00] rounded-none border-2 border-[#CCFF00]" />
-                  <div className="h-8 flex-1 bg-transparent rounded-none border-2 border-[#CCFF00]" />
-                </div>
-                <div className="h-3 w-full bg-neutral-700 rounded-none" />
-                <div className="h-3 w-3/4 bg-neutral-700 rounded-none" />
+            <div className="rounded-lg border border-[#27272A] bg-[#111113] overflow-hidden flex flex-col">
+              <div className="px-5 py-3 border-b border-[#27272A] flex items-center gap-2">
+                <div className="w-2 h-2 rounded-full bg-emerald-500/60" />
+                <span className="text-[10px] font-mono uppercase tracking-wider text-[#71717A]">
+                  PaletteKit prompt
+                </span>
               </div>
-              <p className="text-xs text-green-600 mt-3">
-                Result: Exactly what you envisioned
-              </p>
+              <div className="p-5 flex-1 flex flex-col">
+                <p className="text-sm italic text-[#A1A1AA] mb-5 leading-relaxed">
+                  &ldquo;Neo-Brutalist: 3px black borders, hard 4px offset
+                  shadows, 0px radius. Palette: bg #000, primary #CCFF00,
+                  font: Space Mono 700...&rdquo;
+                </p>
+                {/* Styled mockup */}
+                <div className="mt-auto border-2 border-[#CCFF00] bg-[#0a0a0a] p-3 space-y-2">
+                  <div className="h-2 w-20 bg-[#CCFF00]" />
+                  <div className="flex gap-2">
+                    <div className="h-8 flex-1 bg-[#CCFF00] border-2 border-[#CCFF00]" />
+                    <div className="h-8 flex-1 bg-transparent border-2 border-[#CCFF00]" />
+                  </div>
+                  <div className="h-2.5 w-full bg-[#333]" />
+                  <div className="h-2.5 w-3/4 bg-[#333]" />
+                </div>
+                <p className="text-[10px] text-emerald-400/70 mt-3 font-mono">
+                  Result: Exactly what you envisioned.
+                </p>
+              </div>
             </div>
           </div>
         </div>
       </section>
 
-      {/* CTA */}
-      <section className="py-24 px-6 text-center">
-        <div className="max-w-2xl mx-auto">
-          <h2 className="text-2xl md:text-3xl font-bold mb-4">
-            Ready to build something beautiful?
+      {/* ── Divider ── */}
+      <div className="max-w-7xl mx-auto px-6 lg:px-10">
+        <div className="h-px bg-gradient-to-r from-transparent via-[#27272A] to-transparent" />
+      </div>
+
+      {/* ── Styles Gallery ── */}
+      <section className="py-20 sm:py-28 px-6 lg:px-10">
+        <div className="max-w-6xl mx-auto">
+          <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4 mb-10">
+            <div>
+              <p className="text-xs font-mono tracking-[0.2em] uppercase text-[#52525B] mb-3">
+                Style library
+              </p>
+              <h2 className="text-2xl sm:text-3xl font-serif-display leading-tight">
+                20 styles. Zero guesswork.
+              </h2>
+            </div>
+            <p className="text-sm text-[#71717A] max-w-sm leading-relaxed">
+              Each style is a complete design system &mdash; colors, typography,
+              spacing, effects &mdash; embedded directly in your prompt.
+            </p>
+          </div>
+          <StyleShowcase />
+        </div>
+      </section>
+
+      {/* ── Divider ── */}
+      <div className="max-w-7xl mx-auto px-6 lg:px-10">
+        <div className="h-px bg-gradient-to-r from-transparent via-[#27272A] to-transparent" />
+      </div>
+
+      {/* ── Process ── */}
+      <section className="py-20 sm:py-28 px-6 lg:px-10">
+        <div className="max-w-3xl mx-auto">
+          <p className="text-xs font-mono tracking-[0.2em] uppercase text-[#52525B] mb-4 text-center">
+            How it works
+          </p>
+          <h2 className="text-2xl sm:text-3xl font-serif-display text-center mb-14 leading-tight">
+            Pick. Tune. Prompt.
           </h2>
-          <p className="text-muted-foreground mb-8">
-            Free, no signup, runs entirely in your browser.
+
+          <div className="grid sm:grid-cols-3 gap-8 sm:gap-6">
+            {[
+              {
+                step: "01",
+                title: "Pick your style",
+                desc: "Choose from 20 curated visual aesthetics. Each one sets up colors, fonts, borders, shadows, and effects.",
+              },
+              {
+                step: "02",
+                title: "Tune the details",
+                desc: "Adjust colors, typography, spacing density, border radius, and visual effects. Preview changes live.",
+              },
+              {
+                step: "03",
+                title: "Copy your prompt",
+                desc: "Get a detailed, tool-specific prompt optimized for v0, Lovable, Figma Make, Claude Code, or Cursor.",
+              },
+            ].map(({ step, title, desc }) => (
+              <div key={step} className="relative">
+                <span className="text-4xl font-serif-display text-[#1a1a1e] select-none">
+                  {step}
+                </span>
+                <h3 className="text-sm font-semibold text-[#E4E4E7] mt-3 mb-2">
+                  {title}
+                </h3>
+                <p className="text-xs text-[#71717A] leading-relaxed">{desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── CTA ── */}
+      <section className="relative py-20 sm:py-28 px-6 lg:px-10">
+        {/* Glow */}
+        <div className="absolute inset-0 pointer-events-none overflow-hidden">
+          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[300px] rounded-full bg-amber-500/[0.04] blur-[100px]" />
+        </div>
+
+        <div className="relative max-w-xl mx-auto text-center">
+          <h2 className="text-2xl sm:text-3xl font-serif-display mb-4">
+            Better prompts. Better output.
+          </h2>
+          <p className="text-sm text-[#71717A] mb-8">
+            Free. No signup. Just open the builder and start.
           </p>
           <Link
             href="/builder"
-            className="inline-flex items-center gap-2 px-6 py-3 text-sm font-semibold bg-primary text-primary-foreground rounded-lg hover:opacity-90 transition-opacity"
+            className="inline-flex items-center gap-2.5 px-7 py-3.5 text-sm font-semibold text-[#09090B] bg-[#FAFAF9] rounded-md hover:bg-[#E4E4E7] transition-colors"
           >
-            Open the Builder
+            Open the builder
             <ArrowRight className="h-4 w-4" />
           </Link>
         </div>
       </section>
 
-      {/* Footer */}
-      <footer className="py-8 px-6 border-t border-border text-center text-xs text-muted-foreground">
-        <p>
-          Built with Next.js, Tailwind CSS, and shadcn/ui. PaletteKit is a
-          free, open tool.
-        </p>
+      {/* ── Footer ── */}
+      <footer className="py-8 px-6 lg:px-10 border-t border-[#1a1a1e]">
+        <div className="max-w-7xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4">
+          <div className="flex items-center gap-2">
+            <Sparkles className="h-3.5 w-3.5 text-amber-400/50" />
+            <span className="text-xs text-[#52525B]">
+              Palette<span className="text-[#71717A]">Kit</span>
+            </span>
+          </div>
+          <p className="text-[10px] text-[#3f3f46]">
+            Built with Next.js, Tailwind CSS &amp; shadcn/ui. Free and open.
+          </p>
+        </div>
       </footer>
     </div>
   );

--- a/src/components/home/HeroStyleDemo.tsx
+++ b/src/components/home/HeroStyleDemo.tsx
@@ -1,0 +1,295 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface StyleFrame {
+  name: string;
+  bg: string;
+  cardBg: string;
+  text: string;
+  textMuted: string;
+  primary: string;
+  border: string;
+  radius: string;
+  shadow: string;
+  btnBg: string;
+  btnText: string;
+  btnBorder: string;
+}
+
+const styleFrames: StyleFrame[] = [
+  {
+    name: "Neo-Brutalist",
+    bg: "#FFFFFF",
+    cardBg: "rgba(0,0,0,0.02)",
+    text: "#000000",
+    textMuted: "#555555",
+    primary: "#CCFF00",
+    border: "3px solid #000000",
+    radius: "0px",
+    shadow: "4px 4px 0px #000",
+    btnBg: "#CCFF00",
+    btnText: "#000000",
+    btnBorder: "3px solid #000000",
+  },
+  {
+    name: "Glassmorphism",
+    bg: "#0f0f23",
+    cardBg: "rgba(255,255,255,0.06)",
+    text: "#ffffff",
+    textMuted: "rgba(255,255,255,0.5)",
+    primary: "#7C3AED",
+    border: "1px solid rgba(255,255,255,0.12)",
+    radius: "16px",
+    shadow: "0 8px 32px rgba(0,0,0,0.3)",
+    btnBg: "rgba(124,58,237,0.35)",
+    btnText: "#ffffff",
+    btnBorder: "1px solid rgba(124,58,237,0.4)",
+  },
+  {
+    name: "Swiss International",
+    bg: "#F5F0E8",
+    cardBg: "rgba(0,0,0,0.03)",
+    text: "#1A1A1A",
+    textMuted: "#777777",
+    primary: "#E63946",
+    border: "1px solid #1A1A1A",
+    radius: "0px",
+    shadow: "none",
+    btnBg: "#E63946",
+    btnText: "#ffffff",
+    btnBorder: "1px solid #E63946",
+  },
+  {
+    name: "Clean SaaS",
+    bg: "#FFFFFF",
+    cardBg: "#F9FAFB",
+    text: "#111827",
+    textMuted: "#6B7280",
+    primary: "#4F46E5",
+    border: "1px solid #E5E7EB",
+    radius: "12px",
+    shadow: "0 4px 6px -1px rgba(0,0,0,0.07), 0 2px 4px -2px rgba(0,0,0,0.05)",
+    btnBg: "#4F46E5",
+    btnText: "#ffffff",
+    btnBorder: "1px solid #4F46E5",
+  },
+  {
+    name: "Cinematic Noir",
+    bg: "#0a0a0a",
+    cardBg: "rgba(200,169,126,0.04)",
+    text: "#F5F0E8",
+    textMuted: "rgba(245,240,232,0.4)",
+    primary: "#C8A97E",
+    border: "1px solid rgba(200,169,126,0.15)",
+    radius: "2px",
+    shadow: "0 0 40px rgba(200,169,126,0.04)",
+    btnBg: "transparent",
+    btnText: "#C8A97E",
+    btnBorder: "1px solid rgba(200,169,126,0.5)",
+  },
+];
+
+export function HeroStyleDemo() {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [isPaused, setIsPaused] = useState(false);
+
+  const advance = useCallback(() => {
+    setActiveIndex((prev) => (prev + 1) % styleFrames.length);
+  }, []);
+
+  useEffect(() => {
+    if (isPaused) return;
+    const interval = setInterval(advance, 3200);
+    return () => clearInterval(interval);
+  }, [isPaused, advance]);
+
+  const s = styleFrames[activeIndex];
+
+  return (
+    <div
+      className="relative animate-fade-in-up animation-delay-400"
+      onMouseEnter={() => setIsPaused(true)}
+      onMouseLeave={() => setIsPaused(false)}
+    >
+      {/* Style label */}
+      <div className="flex items-center justify-between mb-3 px-1">
+        <span className="text-xs font-mono text-[#71717A] tracking-wider uppercase">
+          Live preview
+        </span>
+        <span
+          className="text-xs font-mono text-[#A1A1AA] transition-all duration-500"
+          key={activeIndex}
+        >
+          {s.name}
+        </span>
+      </div>
+
+      {/* Browser frame */}
+      <div className="rounded-xl border border-[#27272A] bg-[#18181B] overflow-hidden shadow-2xl shadow-black/40">
+        {/* Title bar */}
+        <div className="flex items-center gap-2 px-4 py-2.5 border-b border-[#27272A]">
+          <div className="flex gap-1.5">
+            <div className="w-2.5 h-2.5 rounded-full bg-[#3f3f46]" />
+            <div className="w-2.5 h-2.5 rounded-full bg-[#3f3f46]" />
+            <div className="w-2.5 h-2.5 rounded-full bg-[#3f3f46]" />
+          </div>
+          <div className="flex-1 mx-8">
+            <div className="h-5 rounded-md bg-[#27272A] max-w-[200px] mx-auto" />
+          </div>
+        </div>
+
+        {/* Content area — the morphing preview */}
+        <div
+          className="p-5 sm:p-6 transition-all duration-700 ease-in-out"
+          style={{ backgroundColor: s.bg }}
+        >
+          {/* Mini nav */}
+          <div
+            className="flex items-center justify-between mb-6 pb-3 transition-all duration-700"
+            style={{ borderBottom: `1px solid ${s.textMuted}33` }}
+          >
+            <div
+              className="h-2 w-14 rounded-sm transition-all duration-700"
+              style={{ backgroundColor: s.text, borderRadius: s.radius === "0px" ? "0px" : "2px" }}
+            />
+            <div className="flex gap-3">
+              <div
+                className="h-1.5 w-8 rounded-sm transition-all duration-700"
+                style={{ backgroundColor: s.textMuted }}
+              />
+              <div
+                className="h-1.5 w-8 rounded-sm transition-all duration-700"
+                style={{ backgroundColor: s.textMuted }}
+              />
+              <div
+                className="h-1.5 w-8 rounded-sm transition-all duration-700"
+                style={{ backgroundColor: s.textMuted }}
+              />
+            </div>
+          </div>
+
+          {/* Hero content */}
+          <div className="space-y-3 mb-6">
+            <div
+              className="h-3 w-3/4 transition-all duration-700"
+              style={{
+                backgroundColor: s.text,
+                borderRadius: s.radius === "0px" ? "0px" : "2px",
+                opacity: 0.9,
+              }}
+            />
+            <div
+              className="h-3 w-1/2 transition-all duration-700"
+              style={{
+                backgroundColor: s.text,
+                borderRadius: s.radius === "0px" ? "0px" : "2px",
+                opacity: 0.9,
+              }}
+            />
+            <div
+              className="h-2 w-5/6 transition-all duration-700"
+              style={{
+                backgroundColor: s.textMuted,
+                borderRadius: s.radius === "0px" ? "0px" : "2px",
+              }}
+            />
+            <div
+              className="h-2 w-2/3 transition-all duration-700"
+              style={{
+                backgroundColor: s.textMuted,
+                borderRadius: s.radius === "0px" ? "0px" : "2px",
+              }}
+            />
+          </div>
+
+          {/* Button */}
+          <div
+            className="inline-flex items-center h-8 px-4 mb-6 transition-all duration-700"
+            style={{
+              backgroundColor: s.btnBg,
+              border: s.btnBorder,
+              borderRadius: s.radius,
+              boxShadow: s.shadow !== "none" ? s.shadow.replace("4px 4px", "2px 2px") : "none",
+            }}
+          >
+            <div
+              className="h-1.5 w-10 rounded-sm transition-all duration-700"
+              style={{ backgroundColor: s.btnText }}
+            />
+          </div>
+
+          {/* Cards row */}
+          <div className="grid grid-cols-3 gap-3">
+            {[0, 1, 2].map((i) => (
+              <div
+                key={i}
+                className="transition-all duration-700 p-3 space-y-2"
+                style={{
+                  backgroundColor: s.cardBg,
+                  border: s.border,
+                  borderRadius: s.radius,
+                  boxShadow: s.shadow,
+                }}
+              >
+                {/* Card accent bar */}
+                <div
+                  className="h-1.5 w-8 transition-all duration-700"
+                  style={{
+                    backgroundColor: s.primary,
+                    borderRadius: s.radius === "0px" ? "0px" : "2px",
+                  }}
+                />
+                {/* Card text lines */}
+                <div
+                  className="h-1 w-full transition-all duration-700"
+                  style={{
+                    backgroundColor: s.text,
+                    opacity: 0.15,
+                    borderRadius: s.radius === "0px" ? "0px" : "1px",
+                  }}
+                />
+                <div
+                  className="h-1 w-3/4 transition-all duration-700"
+                  style={{
+                    backgroundColor: s.text,
+                    opacity: 0.1,
+                    borderRadius: s.radius === "0px" ? "0px" : "1px",
+                  }}
+                />
+                <div
+                  className="h-1 w-1/2 transition-all duration-700"
+                  style={{
+                    backgroundColor: s.text,
+                    opacity: 0.1,
+                    borderRadius: s.radius === "0px" ? "0px" : "1px",
+                  }}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Navigation dots */}
+      <div className="flex items-center justify-center gap-2 mt-4">
+        {styleFrames.map((frame, i) => (
+          <button
+            key={frame.name}
+            onClick={() => setActiveIndex(i)}
+            className="group relative py-2 px-1"
+            aria-label={`Show ${frame.name} style`}
+          >
+            <div
+              className={`h-1 rounded-full transition-all duration-500 ${
+                i === activeIndex
+                  ? "w-6 bg-[#FAFAF9]"
+                  : "w-2 bg-[#3f3f46] group-hover:bg-[#71717A]"
+              }`}
+            />
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/home/StyleShowcase.tsx
+++ b/src/components/home/StyleShowcase.tsx
@@ -4,84 +4,165 @@ import { styles } from "@/data/styles";
 import { getColorTheme } from "@/data/colors";
 import Link from "next/link";
 
+const featuredIds = [
+  "neo-brutalist",
+  "glassmorphism",
+  "swiss-international",
+  "cinematic-noir",
+  "acid-cyber-y2k",
+  "bento-grid",
+  "retro-futurism",
+  "editorial-magazine",
+  "organic-natural",
+  "luxury-premium",
+  "terminal-hacker",
+  "playful-kawaii",
+];
+
 export function StyleShowcase() {
+  const featured = featuredIds
+    .map((id) => styles.find((s) => s.id === id))
+    .filter(Boolean) as typeof styles;
+
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
-      {styles.map((style) => {
-        const theme = getColorTheme(style.defaults.colorThemeId);
-        const colors = theme?.colors;
-        const { tokens } = style;
+    <div>
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+        {featured.map((style) => {
+          const theme = getColorTheme(style.defaults.colorThemeId);
+          const colors = theme?.colors;
+          const { tokens } = style;
 
-        const primary = colors?.primary ?? tokens.textPrimary;
-        const accent = colors?.accent ?? tokens.textSecondary;
-        const isDark =
-          tokens.bgBase === "#000000" ||
-          tokens.bgBase === "#0d1117" ||
-          tokens.bgBase === "#0a0a0a" ||
-          tokens.bgBase === "#0f0f23" ||
-          tokens.bgBase === "#1a1a2e" ||
-          tokens.bgBase === "#0c0c0c";
+          const primary = colors?.primary ?? tokens.textPrimary;
+          const accent = colors?.accent ?? tokens.textSecondary;
 
-        return (
-          <Link
-            key={style.id}
-            href={`/builder?style=${style.id}`}
-            className="group flex flex-col rounded-lg border border-border overflow-hidden hover:border-primary/40 hover:shadow-md transition-all"
-          >
-            {/* Mini preview */}
-            <div
-              className="h-20 p-2.5 flex flex-col gap-1 relative overflow-hidden"
-              style={{ backgroundColor: tokens.bgBase }}
+          return (
+            <Link
+              key={style.id}
+              href={`/builder?style=${style.id}`}
+              className="group relative flex flex-col rounded-lg overflow-hidden border border-[#27272A] hover:border-[#52525B] transition-all duration-300 hover:-translate-y-1 hover:shadow-xl hover:shadow-black/20"
             >
-              {style.defaults.effects.includes("gradient") && (
+              {/* Preview area */}
+              <div
+                className="relative h-28 sm:h-32 p-3 flex flex-col overflow-hidden"
+                style={{ backgroundColor: tokens.bgBase }}
+              >
+                {/* Subtle gradient overlay for atmosphere */}
                 <div
-                  className="absolute inset-0 opacity-25"
+                  className="absolute inset-0 opacity-20"
                   style={{
-                    background: `radial-gradient(ellipse at 30% 50%, ${primary}40 0%, transparent 60%)`,
+                    background: `radial-gradient(ellipse at 30% 20%, ${primary}30 0%, transparent 70%)`,
                   }}
                 />
-              )}
-              {/* Mini heading */}
-              <div className="relative flex flex-col gap-0.5 flex-1 justify-center">
-                <div
-                  className="h-1.5 w-3/4 rounded-sm"
-                  style={{ backgroundColor: tokens.textPrimary, opacity: 0.85 }}
-                />
-                <div
-                  className="h-1 w-1/2 rounded-sm"
-                  style={{ backgroundColor: tokens.textSecondary, opacity: 0.45 }}
-                />
-              </div>
-              {/* Mini cards */}
-              <div className="relative flex gap-1">
-                {[primary, accent].map((color, i) => (
+
+                {/* Mini page preview */}
+                <div className="relative flex flex-col flex-1 justify-center gap-1.5">
+                  {/* Heading bar */}
                   <div
-                    key={i}
-                    className="flex-1 h-5"
+                    className="h-2 w-3/4"
                     style={{
-                      border: `${tokens.borderWidth} solid ${tokens.borderColor}`,
-                      borderRadius: tokens.radiusValue,
-                      boxShadow: tokens.shadowValue,
-                      backgroundColor: isDark
-                        ? "rgba(255,255,255,0.05)"
-                        : "rgba(0,0,0,0.02)",
+                      backgroundColor: tokens.textPrimary,
+                      opacity: 0.85,
+                      borderRadius:
+                        tokens.radiusValue === "0px" ? "0px" : "1px",
                     }}
-                  >
+                  />
+                  {/* Sub text */}
+                  <div
+                    className="h-1.5 w-1/2"
+                    style={{
+                      backgroundColor: tokens.textSecondary,
+                      opacity: 0.5,
+                      borderRadius:
+                        tokens.radiusValue === "0px" ? "0px" : "1px",
+                    }}
+                  />
+                </div>
+
+                {/* Mini cards */}
+                <div className="relative flex gap-1.5 mt-auto">
+                  {[primary, accent].map((color, i) => (
                     <div
-                      className="h-1 mx-1 mt-1 rounded-full opacity-50"
-                      style={{ backgroundColor: color }}
-                    />
-                  </div>
-                ))}
+                      key={i}
+                      className="flex-1 h-8 p-1.5"
+                      style={{
+                        border: `${tokens.borderWidth} solid ${tokens.borderColor}`,
+                        borderRadius: tokens.radiusValue,
+                        boxShadow: tokens.shadowValue,
+                        backgroundColor:
+                          tokens.bgBase === "#000000" ||
+                          tokens.bgBase === "#0d1117" ||
+                          tokens.bgBase === "#0a0a0a" ||
+                          tokens.bgBase === "#0f0f23" ||
+                          tokens.bgBase === "#1a1a2e" ||
+                          tokens.bgBase === "#0c0c0c"
+                            ? "rgba(255,255,255,0.04)"
+                            : "rgba(0,0,0,0.02)",
+                      }}
+                    >
+                      <div
+                        className="h-1 w-3/5 opacity-60"
+                        style={{
+                          backgroundColor: color,
+                          borderRadius:
+                            tokens.radiusValue === "0px" ? "0px" : "1px",
+                        }}
+                      />
+                    </div>
+                  ))}
+                </div>
               </div>
-            </div>
-            {/* Label */}
-            <div className="p-2 bg-card">
-              <p className="text-xs font-semibold truncate">{style.name}</p>
-            </div>
-          </Link>
-        );
-      })}
+
+              {/* Label */}
+              <div className="px-3 py-2.5 bg-[#18181B] border-t border-[#27272A]">
+                <div className="flex items-center justify-between">
+                  <p className="text-xs font-semibold text-[#E4E4E7] truncate">
+                    {style.name}
+                  </p>
+                  <svg
+                    className="w-3 h-3 text-[#52525B] group-hover:text-[#A1A1AA] transition-colors shrink-0 ml-2"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth={2}
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M4.5 19.5l15-15m0 0H8.25m11.25 0v11.25"
+                    />
+                  </svg>
+                </div>
+                <p className="text-[10px] text-[#71717A] mt-0.5 truncate">
+                  {style.description}
+                </p>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+
+      {/* See all link */}
+      <div className="mt-8 text-center">
+        <Link
+          href="/builder"
+          className="inline-flex items-center gap-2 text-sm text-[#A1A1AA] hover:text-[#FAFAF9] transition-colors"
+        >
+          See all 20 styles in the builder
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3"
+            />
+          </svg>
+        </Link>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Complete redesign of the homepage with a dark editorial aesthetic. Replaces generic light-mode design with sophisticated dark theme (#09090B base, amber accent). Added Instrument Serif display font for distinctive typography, created HeroStyleDemo component that animates through 5 visual styles, and simplified copy to be more direct and memorable.

## Changes
- Dark theme redesign with editorial sensibility and ambient glows
- HeroStyleDemo: animated browser frame cycling through Neo-Brutalist → Glassmorphism → Swiss → Clean SaaS → Cinematic Noir with smooth CSS transitions
- Instrument Serif font added for display headings
- Rewritten hero copy: "AI can code anything. It just can't read your mind."
- StyleShowcase redesigned with larger cards, featured 12 styles, "See all 20 in the builder" link
- Simplified "How it works" to minimal three-column layout (Pick. Tune. Prompt.)
- Added CSS animations: fade-in-up with staggered entrance delays
- Grid background texture and subtle ambient glows for depth

## Test Plan
- [ ] Visual check on desktop (1440px) and mobile (375px) – homepage loads with dark theme
- [ ] HeroStyleDemo cycles through styles automatically every 3.2s, stops on hover
- [ ] Navigation button, CTA buttons styled and clickable
- [ ] Style cards link to builder with correct style preset
- [ ] "See all 20 styles" link navigates to builder
- [ ] No console errors, lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)